### PR TITLE
Allow user to specify zoomWrapperTitle in thumbnail gallery

### DIFF
--- a/js/jquery.jqzoom-core.js
+++ b/js/jquery.jqzoom-core.js
@@ -169,9 +169,11 @@
                     thumblist.push(first);
                 }
                 thumblist.each(function () {
+                    //get thumbnail options specified by the user
+                    var thumb_options = $.extend({}, eval("(" + $.trim($(this).attr('rel')) + ")"));
+                    
                     //preloading thumbs
                     if (settings.preloadImages) {
-                        var thumb_options = $.extend({}, eval("(" + $.trim($(this).attr('rel')) + ")"));
                         thumb_preload[i] = new Image();
                         thumb_preload[i].src = thumb_options.largeimage;
                         i++;
@@ -182,6 +184,14 @@
                         });
                         e.preventDefault();
                         obj.swapimage(this);
+                        
+                        //set and show the zoom wrapper title, if specified
+                        zoomtitle = thumb_options.zoomWrapperTitle;
+                        $('.zoomWrapperTitle', this.node).hide();
+                        if (settings.title && zoomtitle.length > 0) {
+                            $('.zoomWrapperTitle', this.node).html(zoomtitle).show();
+                        }
+                        
                         return false;
                     });
                 });


### PR DESCRIPTION
Hi mindprojects,

I downloaded your jqZoom today and have been playing around with it as I'm hoping to use it on my website.  One piece of functionality that I needed was missing, so I've added it and committed it here in case you want to merge the change.  Full details below...

Commit details:
Check for user-specified zoom wrapper title when swapping the main image with a thumbnail image;
Set and show the title accordingly

Full details:
I'm trying out jqZoom with one main zoomable image and a bunch of thumbnails below it.
Here's an example of a test page:
http://rubydemure.com/sandbox/product.php?pid=2

Some of the thumbnails have a title associated with them.  However, as I clicked on thumbnails and they were successfully swapped with the main image, the TITLE in the pop-up zoom window was not updated.

I have added a few lines of code to the "core" JS script to check if the user specified a zoomWrapperTitle and if so (and if title is turned on in the main options), it sets the title in the zoom window and shows it.
Here's an example of an element with the title set:

<div>                                                                               <a href="javascript:void(0);" 
        rel="{
            gallery: 'MYGALLERY', 
            smallimage: 'MYSMALLIMAGE.jpg', 
            largeimage: 'MYLARGEIMAGE.jpg', 
            zoomWrapperTitle: 'THIS IS MY ZOOM TITLE'
        }">
        <img src="<?php echo $paths['Thumb']; ?>" width="50" height="50">
    </a>
</div>


I hope this is helpful - I thought I'd try to contribute something :-)
Kindest regards,
Darina
