### PR TITLE
allow plugin to be reinitalized

### DIFF
--- a/js/jquery.jqzoom-core.js
+++ b/js/jquery.jqzoom-core.js
@@ -35,7 +35,6 @@
     jqzoom = function (el, options) {
         var api = null;
         api = $(el).data("jqzoom");
-        if (api) return api;
         var obj = this;
         var settings = $.extend({}, $.jqzoom.defaults, options || {});
         obj.el = el;


### PR DESCRIPTION
Hello, 
We are using this plugin in a situation where we needed to swap out the image being zoomed so I slightly modified the original code to accomodate this.  You can now swap out the image url and call the jqzoom function again, <code>$('a.yourClass').jqzoom( zoomOpts );</code> to update the image being zoomed.  Thought this could be useful to somebody else.  

Thanks for putting this plugin together,

Paul  
