### PR TITLE
Removes browser check for IE6

### DIFF
--- a/js/jquery.jqzoom-core.js
+++ b/js/jquery.jqzoom-core.js
@@ -20,7 +20,6 @@
  */
 (function ($) {
     //GLOBAL VARIABLES
-    var isIE6 = ($.browser.msie && $.browser.version < 7);
     var body = $(document.body);
     var window = $(window);
     var jqzoompluging_disabled = false; //disabilita globalmente il plugin
@@ -583,23 +582,6 @@
                     this.node.show();
                     break;
                 }
-                if (isIE6 && settings.zoomType != 'innerzoom') {
-                    this.ieframe.width = this.node.width();
-                    this.ieframe.height = this.node.height();
-                    this.ieframe.left = this.node.leftpos;
-                    this.ieframe.top = this.node.toppos;
-                    this.ieframe.css({
-                        display: 'block',
-                        position: "absolute",
-                        left: this.ieframe.left,
-                        top: this.ieframe.top,
-                        zIndex: 99,
-                        width: this.ieframe.width + 'px',
-                        height: this.ieframe.height + 'px'
-                    });
-                    $('.zoomPad', el).append(this.ieframe);
-                    this.ieframe.show();
-                };
             };
         };
 /*========================================================,


### PR DESCRIPTION
This removes the code required for IE6 compatability which is not supported anymore in JQuery 1.9.
