### PR TITLE
jQuery 2 compatibility fix

### DIFF
--- a/js/jquery.jqzoom-core.js
+++ b/js/jquery.jqzoom-core.js
@@ -20,7 +20,7 @@
  */
 (function ($) {
     //GLOBAL VARIABLES
-    var isIE6 = ($.browser.msie && $.browser.version < 7);
+    var isIE6 = ($.browser !== undefined && $.browser.msie && $.browser.version < 7);
     var body = $(document.body);
     var window = $(window);
     var jqzoompluging_disabled = false; //disabilita globalmente il plugin


### PR DESCRIPTION
jQZoom Version 2.3 still works like a charm with jQuery 2 after applying this bugfix. Keeps compatibility with old jQuery versions up.
